### PR TITLE
auto create folders on webdav

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,20 @@ else
     echo "Backup encryption disabled"
 fi
 
+create_folders_by_filepath() {
+    local path="${1#/}" # delete the first slash if there is
+
+    IFS='/' read -ra parts <<< "$path"
+
+    folder_path=""
+    for ((i = 0; i < ${#parts[@]} - 1; i++)); do
+        folder_path="${folder_path}/${parts[i]}"
+        full_path="${WEBDAV_URL}${folder_path}"
+
+        curl -s -u "${WEBDAV_USERNAME}:${WEBDAV_PASSWORD}" -X MKCOL $full_path -o /dev/null
+    done
+}
+
 # Function to send Telegram messages
 send_telegram_message() {
     if [ "$TELEGRAM_ENABLED" = true ]; then
@@ -99,6 +113,8 @@ upload_file() {
     if [ "$ENCRYPTION_ENABLED" = true ]; then
         encrypt_file "$file"
     fi
+
+    create_folders_by_filepath "${WEBDAV_PATH}/${remote_path}"
 
     HTTP_CODE=$(curl -#L -u "${WEBDAV_USERNAME}:${WEBDAV_PASSWORD}" \
             -T "$file" \


### PR DESCRIPTION
Hi!

I'm using your backup with yandex webdav.
Unfortunately, if you upload the file along the way /2025/03/23 then the server returns a 409 error because there are no folder data.

Please add a solution to this problem.
I offer an example.
It might make sense to make folder creation a separate setting, because different webdav servers work differently.

嗨！

我正在使用yandex webdav的备份。
不幸的是，如果一路上传文件/2025/03/23 然后服务器返回409错误，因为没有文件夹数据。

请添加此问题的解决方案。
我举一个例子。
将文件夹创建为单独的设置可能是有意义的，因为不同的webdav服务器的工作方式不同。

P.S
Прости. Я использовал переводчик
Sorry. I used a translator.
不好意思。。。. 我用了一个翻译。